### PR TITLE
updates pyne fast and pyne nightly to use conda

### DIFF
--- a/pyne.fast.run-spec
+++ b/pyne.fast.run-spec
@@ -1,9 +1,9 @@
 run_type    = test
-inputs      = fetch/pyne-ci.git,fetch/fast_deps.scp,fetch/pyne.git,fetch/pytables.git,fetch/numpy.git
-x86_64_MacOSX8_remote_pre_declare = fast_build.sh
-x86_64_Ubuntu12_remote_pre_declare = fast_build.sh
-remote_task = run_test.sh
-platforms   = x86_64_Ubuntu12,x86_64_MacOSX8,
-project     = <a href="http://pyne.io/">PyNE</a>
+inputs = fetch/pyne-ci.git,fetch/pyne.git,fetch/conda-recipes.git,fetch/miniconda_linux.url,fetch/miniconda_mac.url
+x86_64_MacOSX8_remote_pre_declare = conda_build.sh
+x86_64_Ubuntu12_remote_pre_declare = conda_build.sh
+remote_task = conda_test.sh
+platforms = x86_64_MacOSX8,x86_64_Ubuntu12
+project = <a href="http://pyne.io/">PyNE</a>
 project_version = staging (fast)
 description = Builds/Unit tests pyne[staging], <a href="http://gorgus.pyne.io/dashboard">dashboard</a>

--- a/pyne.nightly.run-spec
+++ b/pyne.nightly.run-spec
@@ -1,10 +1,10 @@
-run_type    = test
-inputs      = fetch/pyne-ci.git,fetch/nose.git,fetch/numpy.git,fetch/pytables.git,fetch/numexpr.hg,fetch/cython.git,fetch/pyne.git,fetch/scipy.git,fetch/hdf5.url,fetch/pytaps.url,fetch/moab.url
-x86_64_MacOSX8_remote_pre_declare = build.sh
-x86_64_Ubuntu12_remote_pre_declare = build.sh
-remote_task = run_test.sh
-platforms   = x86_64_Ubuntu12,x86_64_MacOSX8
-project     = <a href="http://pyne.io/">PyNE</a>
+run_type = test
+inputs = fetch/pyne-ci.git,fetch/pyne.git,fetch/conda-recipes.git,fetch/miniconda_linux.url,fetch/miniconda_mac.url
+x86_64_MacOSX8_remote_pre_declare = conda_build.sh
+x86_64_Ubuntu12_remote_pre_declare = conda_build.sh
+remote_task = conda_test.sh
+platforms = x86_64_MacOSX8,x86_64_Ubuntu12
+project = <a href="http://pyne.io/">PyNE</a>
 project_version = staging (nightly)
 description = Builds/Unit tests pyne[staging]
 notify = pyne-dev@googlegroups.com


### PR DESCRIPTION
hi all,

this should employ conda instead of manual builds for our nightly and CI runs.

I think the next steps are
- kill the current nightly cron job on batlab and restart after a pyne-ci repo update
- kill the polyphemus server, update pyne-ci repo, restart server

Whomever does these tasks, could you please add the appropriate steps to the pyne-ci readme?
