### PR TITLE
update MOAB version number

### DIFF
--- a/moab/meta.yaml
+++ b/moab/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: moab
-  version: 4.8.0
+  version: 4.8.1
 
 source:
   fn: moab.tar.gz
-  url: ftp://ftp.mcs.anl.gov/pub/fathom/moab-4.8.0.tar.gz
+  url: ftp://ftp.mcs.anl.gov/pub/fathom/moab-4.8.1.tar.gz
 
 requirements:
   build:


### PR DESCRIPTION
This updates the MOAB version to v4.8.1.  Seems to build and fix import errors.
